### PR TITLE
Add support for hexadecimal escape sequences

### DIFF
--- a/compiler/src/main/php/xp/compiler/emit/Strings.class.php
+++ b/compiler/src/main/php/xp/compiler/emit/Strings.class.php
@@ -50,6 +50,12 @@
           $out.= "\011";
         } else if ('f' === $in{$offset}) {
           $out.= "\014";
+        } else if ('x' === $in{$offset} && ($p= strspn($in, '0123456789ABCDEFabcdef', $offset+ 1))) {
+          if (($n= hexdec(substr($in, $offset+ 1, $p))) > 0xFF) {
+            throw new FormatException('Hex number out of range (\x00 .. \xFF) in '.$in);
+          }
+          $out.= chr($n);
+          $offset+= $p;
         } else if ($p= strspn($in, '01234567', $offset)) {
           if (($n= octdec(substr($in, $offset, $p))) > 0xFF) {
             throw new FormatException('Octal number out of range (\0 .. \377) in '.$in);

--- a/compiler/src/test/php/net/xp_lang/tests/StringEscapes.class.php
+++ b/compiler/src/test/php/net/xp_lang/tests/StringEscapes.class.php
@@ -102,12 +102,66 @@
     }
 
     /**
+     * Test "\00"
+     *
+     */
+    #[@test]
+    public function octalNulTwo() {
+      $this->assertEquals("Hello\000World", Strings::expandEscapesIn('Hello\00World'));
+    }
+
+    /**
+     * Test "\000"
+     *
+     */
+    #[@test]
+    public function octalNulThree() {
+      $this->assertEquals("Hello\000World", Strings::expandEscapesIn('Hello\000World'));
+    }
+
+    /**
+     * Test "\x0"
+     *
+     */
+    #[@test]
+    public function hexNulOne() {
+      $this->assertEquals("Hello\000World", Strings::expandEscapesIn('Hello\x0World'));
+    }
+
+    /**
+     * Test "\x00"
+     *
+     */
+    #[@test]
+    public function hexNulTwo() {
+      $this->assertEquals("Hello\000World", Strings::expandEscapesIn('Hello\x00World'));
+    }
+
+    /**
      * Test "\377" octal escape (0xFF)
      *
      */
     #[@test]
-    public function ff() {
+    public function octalFF() {
       $this->assertEquals("Hello\377World", Strings::expandEscapesIn('Hello\377World'));
+    }
+
+    /**
+     * Test "\xff" octal escape (0xFF)
+     *
+     */
+    #[@test]
+    public function hexFFLowercase() {
+      $this->assertEquals("Hello\377World", Strings::expandEscapesIn('Hello\xffWorld'));
+    }
+
+    /**
+     * Test "\xff" octal escape (0xFF)
+     *
+     */
+    #[@test]
+    public function hexFFUppercasecase() {
+      $this->assertEquals("Hello\377World", Strings::expandEscapesIn('Hello\xFFWorld'));
     }
 
     /**
@@ -117,6 +171,15 @@
     #[@test, @expect('lang.FormatException')]
     public function octalNumberOutOfRange() {
       Strings::expandEscapesIn('Hello\400World');
+    }
+
+    /**
+     * Test "\xFFFF" hex escape is out of range
+     *
+     */
+    #[@test, @expect('lang.FormatException')]
+    public function hexNumberOutOfRange() {
+      Strings::expandEscapesIn('Hello\xFFFFWorld');
     }
 
     /**


### PR DESCRIPTION
Implements escape sequences of the format `\x   hex-digit   hex-digitopt   hex-digitopt   hex-digitopt` in strings.
