### PR TITLE
Make use of composed modules

### DIFF
--- a/compiler/src/main/php/module.xp
+++ b/compiler/src/main/php/module.xp
@@ -7,7 +7,7 @@
  /**
   * The XP Compiler
   */
-  module xp-framework/compiler(1.9.0-dev) {
+  module xp-framework/compiler(1.9.0-dev) provides xp.compiler {
 
   }
 ?>

--- a/compiler/src/main/php/xp/compiler/JitClassLoader.class.php
+++ b/compiler/src/main/php/xp/compiler/JitClassLoader.class.php
@@ -149,5 +149,14 @@
     public function toString() {
       return $this->getClassName().'<@classpath>';
     }
+
+    /**
+     * Returns instance ID
+     *
+     * @return  string
+     */
+    public function instanceId() {
+      return 'jit';
+    }
   }
 ?>

--- a/compiler/src/test/php/module.xp
+++ b/compiler/src/test/php/module.xp
@@ -5,9 +5,9 @@
  */
 
  /**
-  * The XP Compiler
+  * The XP Compiler's unittests
   */
-  module xp-framework/compiler.test(1.9.0-dev) {
+  module tests extends xp-framework/compiler provides net.xp_lang.tests {
 
   }
 ?>


### PR DESCRIPTION
This pull request makes use of the composed modules idea from xp-framework/xp-framework#231 and changes the compiler's test suite to be an extended module inside the `xp-framework/compiler` module.
## Before

```
Module<xp-framework/compiler:1.9.0-dev>@{
  ** @FileSystemCL<...\xp.thekid.lang\compiler\src\main\php\>
}
Module<xp-framework/compiler.test:1.9.0-dev>@{
  ** @FileSystemCL<...\xp.thekid.lang\compiler\src\test\php\>
}
```
## After

```
Module<xp-framework/compiler:1.9.0-dev>@{
  xp.compiler @FileSystemCL<...\xp.thekid.lang\compiler\src\main\php\>
  tests: net.xp_lang.tests @FileSystemCL<...\xp.thekid.lang\compiler\src\test\php\>
}
```
