### PR TITLE
Determine enum member type correctly

### DIFF
--- a/compiler/src/main/php/xp/compiler/types/TypeReflection.class.php
+++ b/compiler/src/main/php/xp/compiler/types/TypeReflection.class.php
@@ -320,8 +320,9 @@
         $f->name= $field->getName();
         $f->modifiers= $field->getModifiers();
         if ($this->class->isEnum() && ($f->modifiers & (MODIFIER_PUBLIC | MODIFIER_STATIC))) {
-          if ($this->class->isInstance($field->get(NULL))) {
-            $f->type= $this->typeNameOf($this->class->getName());
+          $member= $field->get(NULL);
+          if ($this->class->isInstance($member)) {
+            $f->type= $this->typeNameOf(xp::typeOf($member));
           } else {
             $f->type= $this->typeNameOf($field->getTypeName());
           }

--- a/compiler/src/test/php/net/xp_lang/tests/types/TypeReflectionTest.class.php
+++ b/compiler/src/test/php/net/xp_lang/tests/types/TypeReflectionTest.class.php
@@ -318,14 +318,40 @@
 
     /**
      * Test enum member type
-     *
      */
     #[@test]
     public function enumMemberType() {
-      $enum= create(new TypeReflection(XPClass::forName('lang.CommandLine')));
+      $cl= ClassLoader::defineClass('TypeReflectionTest_Enum', 'lang.Enum', array(), '{
+        public static $a= 0, $b;
+      }');
       $this->assertEquals(
-        new TypeName('lang.CommandLine'),
-        $enum->getField('WINDOWS')->type
+        new TypeName($cl->getField('b')->get(NULL)->getClassName()),
+        create(new TypeReflection($cl))->getField('b')->type
+      );
+    }
+
+    /**
+     * Test enum member type
+     */
+    #[@test]
+    public function abstractEnumMemberType() {
+      $cl= ClassLoader::defineClass('TypeReflectionTest_AbstractEnum', 'lang.Enum', array(), '{
+        public static $a, $b;
+
+        static function __static() {
+          self::$a= newinstance(__CLASS__, array(0, "a"), "{
+            static function __static() { }
+            public function code() { return 97; }
+          }");
+          self::$a= newinstance(__CLASS__, array(1, "b"), "{
+            static function __static() { }
+            public function code() { return 98; }
+          }");
+        }
+      }');
+      $this->assertEquals(
+        new TypeName($cl->getField('a')->get(NULL)->getClassName()),
+        create(new TypeReflection($cl))->getField('a')->type
       );
     }
   }


### PR DESCRIPTION
This pull request fixes warning about access on enum members being deferred until runtime.

``` php
$reflect= new TypeReflection(XPClass::forName('lang.CommandLine'));
$type= $enum->getField('WINDOWS')->type;     // Now lang.CommandLine, before: var
```
