### PR TITLE
Fix capturing of local variables in lambdas

### DIFF
--- a/src/main/php/xp/compiler/ast/Visitor.class.php
+++ b/src/main/php/xp/compiler/ast/Visitor.class.php
@@ -486,7 +486,6 @@ abstract class Visitor extends \lang\Object {
    * @param   xp.compiler.ast.Node node
    */
   protected function visitLambda(LambdaNode $node) {
-    $node->parameters= $this->visitAll((array)$node->parameters);
     $node->statements= $this->visitAll((array)$node->statements);
     return $node;
   }

--- a/src/main/php/xp/compiler/emit/php/Emitter.class.php
+++ b/src/main/php/xp/compiler/emit/php/Emitter.class.php
@@ -1361,7 +1361,7 @@ abstract class Emitter extends \xp\compiler\emit\Emitter {
     );
     
     $name= 'operator··'.$ovl[$operator->symbol];
-    $this->enter(new MethodScope($name));
+    $this->enter(new MethodScope($operator));
     array_unshift($this->method, $name);
 
     // Meta data
@@ -1601,7 +1601,7 @@ abstract class Emitter extends \xp\compiler\emit\Emitter {
     $b->append(' function '.$method->name);
     
     // Begin
-    $this->enter(new MethodScope($method->name));
+    $this->enter(new MethodScope($method));
     array_unshift($this->method, $method->name);
     if (!Modifiers::isStatic($method->modifiers)) {
       $this->scope[0]->setType(new VariableNode('this'), $this->scope[0]->declarations[0]->name);
@@ -1673,7 +1673,7 @@ abstract class Emitter extends \xp\compiler\emit\Emitter {
     $b->append(' function __construct');
     
     // Begin
-    $this->enter(new MethodScope('__construct'));
+    $this->enter(new MethodScope($constructor));
     $this->scope[0]->setType(new VariableNode('this'), $this->scope[0]->declarations[0]->name);
     array_unshift($this->method, '__construct');
 

--- a/src/main/php/xp/compiler/emit/php/Emitter.class.php
+++ b/src/main/php/xp/compiler/emit/php/Emitter.class.php
@@ -1834,7 +1834,7 @@ abstract class Emitter extends \xp\compiler\emit\Emitter {
     $auto= [];
     if (!empty($properties['get'])) {
       $b->append('function __get($'.$mangled.') {');
-      $this->enter(new MethodScope('__get'));
+      $this->enter(new MethodScope(new MethodNode(['name' => '__get'])));
       $this->scope[0]->setType(new VariableNode('this'), $this->scope[0]->declarations[0]->name);
       foreach ($properties['get'] as $name => $definition) {
         $b->append('if (\''.$name.'\' === $'.$mangled.') {');
@@ -1851,7 +1851,7 @@ abstract class Emitter extends \xp\compiler\emit\Emitter {
     }
     if (!empty($properties['set'])) {
       $b->append('function __set($'.$mangled.', $value) {');
-      $this->enter(new MethodScope('__set'));
+      $this->enter(new MethodScope(new MethodNode(['name' => '__set', 'parameters' => [['name' => 'value']]])));
       $this->scope[0]->setType(new VariableNode('this'), $this->scope[0]->declarations[0]->name);
       foreach ($properties['set'] as $name => $definition) {
         $this->scope[0]->setType(new VariableNode('value'), $definition[0]);

--- a/src/main/php/xp/compiler/emit/php/Emitter.class.php
+++ b/src/main/php/xp/compiler/emit/php/Emitter.class.php
@@ -1940,7 +1940,7 @@ abstract class Emitter extends \xp\compiler\emit\Emitter {
 
       if (!$initializable) {
         $init= new Buffer('', $b->line);
-        $this->enter(new MethodScope('<init>'));
+        $this->enter(new MethodScope(new MethodNode(['name' => '<init>'])));
         if ($static) {
           $variable= new StaticMemberAccessNode(new TypeName('self'), $field->name);
         } else {

--- a/src/main/php/xp/compiler/emit/php/V54Emitter.class.php
+++ b/src/main/php/xp/compiler/emit/php/V54Emitter.class.php
@@ -88,7 +88,7 @@ class V54Emitter extends Emitter {
     // Capture all local variables and parameters of containing scope which
     // are also used inside the lambda by value.
     $finder= new \xp\compiler\ast\LocalVariableFinder();
-    foreach ($finder->variablesIn($this->scope[0]->routine->body) as $variable) {
+    foreach ($finder->variablesIn((array)$this->scope[0]->routine->body) as $variable) {
       $finder->including($variable);
     }
     foreach ($this->scope[0]->routine->parameters as $param) {

--- a/src/main/php/xp/compiler/types/MethodScope.class.php
+++ b/src/main/php/xp/compiler/types/MethodScope.class.php
@@ -1,20 +1,20 @@
 <?php namespace xp\compiler\types;
 
 /**
- * Represents the method scope
+ * Represents the routine scope
  *
  * @see     xp://xp.compiler.Scope
  */
 class MethodScope extends Scope {
-  public $name= null;
+  public $routine= null;
 
   /**
    * Constructor
    *
-   * @param   string name
+   * @param   xp.compiler.ast.RoutineNode $routine
    */
-  public function __construct($name= null) {
-    $this->name= $name;
+  public function __construct($routine= null) {
+    $this->routine= $routine;
     parent::__construct();
   }
 }

--- a/src/test/php/net/xp_lang/tests/VisitorTest.class.php
+++ b/src/test/php/net/xp_lang/tests/VisitorTest.class.php
@@ -851,9 +851,9 @@ class VisitorTest extends \unittest\TestCase {
    */
   #[@test]
   public function visitLambda() {
-    $node= new \xp\compiler\ast\LambdaNode(array(new VariableNode('a')), array(new ReturnNode()));
+    $node= new \xp\compiler\ast\LambdaNode(array(['name' => 'a']), array(new ReturnNode()));
     $this->assertVisited(
-      array($node, $node->parameters[0], $node->statements[0]), 
+      array($node, $node->statements[0]), 
       $node
     );
   }
@@ -864,9 +864,9 @@ class VisitorTest extends \unittest\TestCase {
    */
   #[@test]
   public function visitLambdaWithEmptyStatements() {
-    $node= new \xp\compiler\ast\LambdaNode(array(new VariableNode('a')), array());
+    $node= new \xp\compiler\ast\LambdaNode(array(['name' => 'a']), array());
     $this->assertVisited(
-      array($node, $node->parameters[0]), 
+      array($node), 
       $node
     );
   }

--- a/src/test/php/net/xp_lang/tests/execution/source/LambdaTest.class.php
+++ b/src/test/php/net/xp_lang/tests/execution/source/LambdaTest.class.php
@@ -50,4 +50,23 @@ class LambdaTest extends ExecutionTest {
       '$plusone= $a -> $a + 1; return $plusone(2);'
     ));
   }
+
+  #[@test]
+  public function inside_property_getter() {
+    $class= self::define('class', 'LambdaInsidePropertyGetter', null, '{
+      public var inc { get { return $a -> ++$a; } }
+      public int test(int $param) { return ($this.inc)($param); } 
+    }');
+    $this->assertEquals(2, $class->newInstance()->test(1));
+  }
+
+  #[@test]
+  public function inside_property_setter() {
+    $class= self::define('class', 'LambdaInsidePropertySetter', null, '{
+      private var $func;
+      public var inc { set { $this.func= $a -> $a + $value; } }
+      public int test(int $param) { $this.inc= $param; return ($this.func)($param); } 
+    }');
+    $this->assertEquals(2, $class->newInstance()->test(1));
+  }
 }

--- a/src/test/php/net/xp_lang/tests/execution/source/LambdaTest.class.php
+++ b/src/test/php/net/xp_lang/tests/execution/source/LambdaTest.class.php
@@ -69,4 +69,13 @@ class LambdaTest extends ExecutionTest {
     }');
     $this->assertEquals(2, $class->newInstance()->test(1));
   }
+
+  #[@test]
+  public function inside_field_initializer() {
+    $class= self::define('class', 'LambdaInsideFieldInitializer', null, '{
+      public var $inc= $a -> $a + 1;
+      public int test(int $param) { return ($this.inc)($param); } 
+    }');
+    $this->assertEquals(2, $class->newInstance()->test(1));
+  }
 }

--- a/src/test/php/net/xp_lang/tests/execution/source/LambdaTest.class.php
+++ b/src/test/php/net/xp_lang/tests/execution/source/LambdaTest.class.php
@@ -30,6 +30,14 @@ class LambdaTest extends ExecutionTest {
   }
 
   #[@test]
+  public function closure_local_variables_not_captured() {
+    $this->assertEquals(array(3, 6, 9), $this->run(
+      'return apply([1, 2, 3], $a -> { $mul= 3; return $a * $mul; });',
+      array('import static net.xp_lang.tests.execution.source.Functions::apply;')
+    ));
+  }
+
+  #[@test]
   public function execution() {
     $this->assertEquals(3, $this->run(
       'return ($a -> $a + 1)(2);'


### PR DESCRIPTION
The lambda was also capturing variables declared only locally inside the lambda itself, which lead to an "undefined variable" warning.

Example:

```php
void scope() {
  $factor= 3;
  return $a -> {
    $base= 100;
    return $base + $factor * 3;
  };
}
```

Above, factor needs to be captured, while base should not be